### PR TITLE
Set caching configs to their default values

### DIFF
--- a/charts/canton-participant/templates/configmap.yaml
+++ b/charts/canton-participant/templates/configmap.yaml
@@ -60,9 +60,11 @@ data:
             {{- end }}
 
             command-service.max-commands-in-flight = {{ int .Values.commandService.maxCommandsInFlight }}
-            max-contract-state-cache-size = {{ int .Values.caching.maxContractStateCacheSize }}
-            max-contract-key-state-cache-size = {{ int .Values.caching.maxContractKeyStateCacheSize }}
-            max-transactions-in-memory-fan-out-buffer-size = {{ int .Values.caching.maxTransactionsInMemoryFanOutBufferSize }}
+            index-service {
+              max-contract-state-cache-size = {{ int .Values.caching.maxContractStateCacheSize }}
+              max-contract-key-state-cache-size = {{ int .Values.caching.maxContractKeyStateCacheSize }}
+              max-transactions-in-memory-fan-out-buffer-size = {{ int .Values.caching.maxTransactionsInMemoryFanOutBufferSize }}
+            }
           }
 
           admin-api {

--- a/charts/canton-participant/values.yaml
+++ b/charts/canton-participant/values.yaml
@@ -518,11 +518,11 @@ authServices:
 ## @param caching.contractStore.expireAfterAccess Expiry time after accessing values from the synchronisation protocol's contract store cache.
 ##
 caching:
-  maxContractStateCacheSize: 1000000
-  maxContractKeyStateCacheSize: 1000000
-  maxTransactionsInMemoryFanOutBufferSize: 100000
+  maxContractStateCacheSize: 10000
+  maxContractKeyStateCacheSize: 10000
+  maxTransactionsInMemoryFanOutBufferSize: 1000
   contractStore:
-    maxSize: 1000000
+    maxSize: 10000
     expireAfterAccess: "10m"
 
 ## @section Command Service configuration


### PR DESCRIPTION
Before this change, the caching configs were set at unreasonable high values which would have a negative performance impact and potentially lead to OOM. Now, they are set to the default values.